### PR TITLE
Fix index link to storyboard and rebuild site

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <a href="apps/website/sandbox/">Tools Sandbox</a> |
     <a href="apps/website/ai-tools/">AI Tools</a> |
     <a href="apps/website/brief/">Brief for AI agent</a> |
-    <a href="apps/website/lifecycle/">Lifecycle</a> |
+    <a href="apps/website/storyboard/">Storyboard</a> |
     <a href="apps/website/insights/">Insights</a> |
     <a href="app-index.html">App Index</a>
   </nav>


### PR DESCRIPTION
## Summary
- fix navigation link to `Storyboard` page
- rebuild docs so that the new gallery page renders correctly

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878f7641660833286b7f121926f226d