### PR TITLE
Increase boot timeout for global WBS sheaf app

### DIFF
--- a/apps/global-WBS-by-sheaf/index.html
+++ b/apps/global-WBS-by-sheaf/index.html
@@ -490,7 +490,7 @@
 </head>
 <body>
   <p class="back-link"><a href="../../index.html">Back to app index</a></p>
-  <div id="app" class="app min-h-64" data-timeout="3000">
+  <div id="app" class="app min-h-64" data-timeout="12000">
     <noscript>Interactive visualisation requires JavaScript enabled.</noscript>
     <div class="skeleton" aria-hidden="true">
       <div class="skline" style="width:60%"></div>


### PR DESCRIPTION
### Motivation
- Increase the interactive boot watchdog timeout to reduce false fallbacks to the static view when the canvas initialization takes longer than expected.

### Description
- Changed the `data-timeout` value in `apps/global-WBS-by-sheaf/index.html` from `3000` to `12000`, which raises the `timeoutMs` used by the inline boot watchdog script.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698508a3dbc88332b6b2d2935e25ebfd)